### PR TITLE
Only consider PT_LOAD at Offset == 0

### DIFF
--- a/hemfix/hemfix.go
+++ b/hemfix/hemfix.go
@@ -116,6 +116,10 @@ func fixelf(elf *ELF.File, fd io.ReadWriteSeeker) error {
 			continue
 		}
 
+		if p.Off != 0 {
+			continue
+		}
+
 		mask := -p.Align
 		if ^mask&p.Vaddr != 0 && (^mask&(p.Vaddr-p.Off)) == 0 {
 			log.Printf("Hemming PT_LOAD section")
@@ -130,6 +134,7 @@ func fixelf(elf *ELF.File, fd io.ReadWriteSeeker) error {
 
 			dst := off + int64(sz*i)
 			writephdr(elf, dst, fd, p)
+			break
 		}
 	}
 	return nil


### PR DESCRIPTION
This fix prevents us modifying PT_LOADs we shouldn't touch.

Thanks to [John Reiser](http://www.bitwagon.com/) for [helping diagnose and fix](http://sourceforge.net/p/upx/bugs/195/).
