### PR TITLE
Add compression parameters

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 )
 
-const usageText = `usage: goupx [args...] files...\n
+const usageText = `usage: goupx [args...] files...
       
     --no-upx: Disables UPX from running.
     --strip-binary: Strips binaries before compressing them.

--- a/main.go
+++ b/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"flag"
-	"fmt"
 	"github.com/pwaller/goupx/hemfix"
 	"log"
 	"os"
@@ -11,92 +9,81 @@ import (
 
 const usageText = "usage: goupx [args...] path\n"
 
-var (
-	run_strip               = flag.Bool("s", false, "run strip")
-	run_upx                 = flag.Bool("u", true, "run upx")
-	manual_compression      = flag.Uint("c", 0, "Manual Compression Level: (1-9)")
-	best_compression        = flag.Bool("best", false, "Best Compression")
-	brute_compression       = flag.Bool("brute", false, "Brute Compression")
-	ultra_brute_compression = flag.Bool("ultra-brute", false, "Ultra Brute Compression")
-)
+var run_strip = false
+var run_upx = true
 
 // usage prints some nice output instead of panic stacktrace when an user calls
 // goupx without arguments
 func usage() {
 	os.Stderr.WriteString(usageText)
-	flag.PrintDefaults()
 }
 
-// checkCompressionLevel sets the compression level to 9 if it is higher than
-// the maximum limit
-func checkCompressionLevel() {
-	if *manual_compression > uint(9) {
-		*manual_compression = uint(9)
+// parseArguments parses arguments from os.Args and separates the goupx flags
+// from the UPX flags, as well as separating the files from the arguments.
+func parseArguments() (args []string, files []string) {
+	args = append(args, "/usr/bin/upx")
+	for _, arg := range os.Args[1:] {
+		switch {
+		case arg == "-h" || arg == "--help":
+			usage()
+		case arg == "--no-upx":
+			run_upx = false
+		case arg == "--strip-binary":
+			run_strip = true
+		case arg[0] != '-':
+			files = append(files, arg)
+		default:
+			args = append(args, arg)
+		}
+	}
+	return
+}
+
+// compressBinary attempts to compress the binary with UPX.
+func compressBinary(input_file string, arguments []string) {
+	if run_upx {
+		cmd := &exec.Cmd{
+			Path:   "/usr/bin/upx",
+			Args:   append(arguments, input_file),
+			Stdout: os.Stdout,
+			Stderr: os.Stderr,
+		}
+		if err := cmd.Run(); err != nil {
+			log.Panic("upx failed: ", err)
+		}
 	}
 }
 
 // stripBinary attempts to strip the binary.
 func stripBinary(input_file string) {
-	cmd := exec.Command("strip", "-s", input_file)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		log.Panic("strip failed: ", err)
-	}
-}
-
-// compressBinary attempts to compress the binary with UPX.
-func compressBinary(input_file string) {
-	var cmd *exec.Cmd
-	if *best_compression {
-		cmd = exec.Command("upx", "--best", input_file)
-	} else if *brute_compression {
-		cmd = exec.Command("upx", "--brute", input_file)
-	} else if *ultra_brute_compression {
-		cmd = exec.Command("upx", "--ultra-brute", input_file)
-	} else if *manual_compression != 0 {
-		cmd = exec.Command("upx",
-			fmt.Sprintf("%s%d", "-", *manual_compression), input_file)
-	} else {
-		cmd = exec.Command("upx", input_file)
-	}
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		log.Panic("upx failed: ", err)
-	}
-}
-
-func main() {
-	flag.Parse()
-
-	if flag.NArg() != 1 {
-		usage()
-		return
-	}
-
-	checkCompressionLevel()
-
-	defer func() {
-		if err := recover(); err != nil {
-			log.Print("Panicked. Giving up.")
-			panic(err)
-			return
+	if run_strip {
+		cmd := exec.Command("strip", "-s", input_file)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			log.Panic("strip failed: ", err)
 		}
-	}()
+	}
+}
 
-	input_file := flag.Arg(0)
-	err := hemfix.FixFile(input_file)
-	if err != nil {
+// runHemfix will attempt to fix the current input file.
+func runHemfix(input_file string) {
+	if err := hemfix.FixFile(input_file); err != nil {
 		log.Panicf("Failed to fix '%s': %v", input_file, err)
 	}
 	log.Print("File fixed!")
+}
 
-	if *run_strip {
-		stripBinary(input_file)
+func main() {
+	arguments, files := parseArguments()
+	for _, file := range files {
+		runHemfix(file)
+		stripBinary(file)
+		compressBinary(file, arguments)
 	}
-
-	if *run_upx {
-		compressBinary(input_file)
+	if err := recover(); err != nil {
+		log.Print("Panicked. Giving up.")
+		panic(err)
+		return
 	}
 }

--- a/main.go
+++ b/main.go
@@ -7,7 +7,12 @@ import (
 	"os/exec"
 )
 
-const usageText = "usage: goupx [args...] path\n"
+const usageText = `usage: goupx [args...] files...\n
+      
+    --no-upx: Disables UPX from running.
+    --strip-binary: Strips binaries before compressing them.
+      
+See UPX's documentation (man upx) for information on UPX's flags.`
 
 var run_strip = false
 var run_upx = true

--- a/main.go
+++ b/main.go
@@ -12,7 +12,8 @@ const usageText = `usage: goupx [args...] files...
     --no-upx: Disables UPX from running.
     --strip-binary: Strips binaries before compressing them.
       
-See UPX's documentation (man upx) for information on UPX's flags.`
+See UPX's documentation (man upx) for information on UPX's flags.
+`
 
 var run_strip = false
 var run_upx = true
@@ -26,6 +27,9 @@ func usage() {
 // parseArguments parses arguments from os.Args and separates the goupx flags
 // from the UPX flags, as well as separating the files from the arguments.
 func parseArguments() (args []string, files []string) {
+	if len(os.Args) == 1 {
+		usage()
+	}
 	args = append(args, "/usr/bin/upx")
 	for _, arg := range os.Args[1:] {
 		switch {
@@ -48,11 +52,11 @@ func parseArguments() (args []string, files []string) {
 func compressBinary(input_file string, arguments []string) {
 	if run_upx {
 		cmd := &exec.Cmd{
-			Path:   "/usr/bin/upx",
-			Args:   append(arguments, input_file),
-			Stdout: os.Stdout,
-			Stderr: os.Stderr,
+			Path: "/usr/bin/upx",
+			Args: append(arguments, input_file),
 		}
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
 			log.Panic("upx failed: ", err)
 		}

--- a/main.go
+++ b/main.go
@@ -2,32 +2,80 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"github.com/pwaller/goupx/hemfix"
 	"log"
 	"os"
 	"os/exec"
-
-	"github.com/pwaller/goupx/hemfix"
 )
 
 const usageText = "usage: goupx [args...] path\n"
 
-// usage prints some nice output instead of panic stacktrace when an user calls goupx without arguments
+var (
+	run_strip               = flag.Bool("s", false, "run strip")
+	run_upx                 = flag.Bool("u", true, "run upx")
+	manual_compression      = flag.Uint("c", 0, "Manual Compression Level: (1-9)")
+	best_compression        = flag.Bool("best", false, "Best Compression")
+	brute_compression       = flag.Bool("brute", false, "Brute Compression")
+	ultra_brute_compression = flag.Bool("ultra-brute", false, "Ultra Brute Compression")
+)
+
+// usage prints some nice output instead of panic stacktrace when an user calls
+// goupx without arguments
 func usage() {
 	os.Stderr.WriteString(usageText)
 	flag.PrintDefaults()
 }
 
+// checkCompressionLevel sets the compression level to 9 if it is higher than
+// the maximum limit
+func checkCompressionLevel() {
+	if *manual_compression > uint(9) {
+		*manual_compression = uint(9)
+	}
+}
+
+// stripBinary attempts to strip the binary.
+func stripBinary(input_file string) {
+	cmd := exec.Command("strip", "-s", input_file)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		log.Panic("strip failed: ", err)
+	}
+}
+
+// compressBinary attempts to compress the binary with UPX.
+func compressBinary(input_file string) {
+	var cmd *exec.Cmd
+	if *best_compression {
+		cmd = exec.Command("upx", "--best", input_file)
+	} else if *brute_compression {
+		cmd = exec.Command("upx", "--brute", input_file)
+	} else if *ultra_brute_compression {
+		cmd = exec.Command("upx", "--ultra-brute", input_file)
+	} else if *manual_compression != 0 {
+		cmd = exec.Command("upx",
+			fmt.Sprintf("%s%d", "-", *manual_compression), input_file)
+	} else {
+		cmd = exec.Command("upx", input_file)
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		log.Panic("upx failed: ", err)
+	}
+}
+
 func main() {
-
-	run_strip := flag.Bool("s", false, "run strip")
-	run_upx := flag.Bool("u", true, "run upx")
-
 	flag.Parse()
 
 	if flag.NArg() != 1 {
 		usage()
 		return
 	}
+
+	checkCompressionLevel()
 
 	defer func() {
 		if err := recover(); err != nil {
@@ -45,23 +93,10 @@ func main() {
 	log.Print("File fixed!")
 
 	if *run_strip {
-		cmd := exec.Command("strip", "-s", input_file)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		err = cmd.Run()
-		if err != nil {
-			log.Panic("strip failed: ", err)
-		}
+		stripBinary(input_file)
 	}
 
 	if *run_upx {
-		cmd := exec.Command("upx", input_file)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		err = cmd.Run()
-		if err != nil {
-			log.Panic("upx failed: ", err)
-		}
+		compressBinary(input_file)
 	}
-
 }


### PR DESCRIPTION
Added manual compression, best, brute and ultra-brute compression flags.
Manual compression is called with the -c flag and ranges from 1 through 9.
-best, -brute and -ultra-brute call their repective UPX compression levels.